### PR TITLE
MATT-1378 upgrade eirslett plugin to work with current maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 			<plugin>
 			    <groupId>com.github.eirslett</groupId>
 			    <artifactId>frontend-maven-plugin</artifactId>
-			    <version>0.0.15</version>
+			    <version>0.0.23</version>
 			    
 			    <configuration>
 			        <workingDirectory>.</workingDirectory>


### PR DESCRIPTION
This fix allows us to upgrade to the latest maven when we want and not prevent us from upgrading. The eirslett 0.23 is backwards compatible with mvn3.1 so it will not affect the current build.

Ref DCE ticket: https://tools.dce.harvard.edu/jira/browse/MATT-1378. 

NOTE: the source pom.xml for this DCE pom.xml is matterhorn-modules/<release versions>. Request to upgrade those  https://github.com/polimediaupv/paella-matterhorn/issues/15