### PR TITLE
MATT-1373 link to combo pub list for DCE offerings

### DIFF
--- a/paella-matterhorn/plugins/edu.harvard.dce.infoButtonPlugin/dce_infobutton.js
+++ b/paella-matterhorn/plugins/edu.harvard.dce.infoButtonPlugin/dce_infobutton.js
@@ -51,7 +51,16 @@ Class ('paella.plugins.InfoPlugin', paella.ButtonPlugin,{
       case ('All Course Videos'):
         if (paella.matterhorn && paella.matterhorn.episode && paella.matterhorn.episode.dcIsPartOf){
           var seriesId = paella.matterhorn.episode.dcIsPartOf;
-          location.href = '../ui/publicationListing.shtml?seriesId=' + seriesId;
+          // MATT-1373 reference combined pub list page when series looks like the DCE <academicYear><term><crn>
+          if (seriesId.match('^[0-9]{11}$')) {
+            var academicYear = seriesId.slice(0,4);
+            var academicTerm = seriesId.slice(4,6);
+            var courseCrn = seriesId.slice(6,11);
+            location.href = '../ui/#/' + academicYear + '/' + academicTerm + '/' + courseCrn;
+          } else {
+             // For an unknown series signature, reference the old 1.4x MH only, pub list page
+             location.href = '../ui/publicationListing.shtml?seriesId=' + seriesId;
+          }
         } 
         else {
           message = 'No other lectures found.';


### PR DESCRIPTION
MATT-1373 pub list link to combo page for valid DCE offerings, or old 1.4 MH only pub page for MH series (non-DCE, usually from a test series i.e. a UUID like 12342442-sdfdsdgsg-233232-sdfdfdf)