### PR TITLE
MATT-1577 Remove Admin dependency: Get series from Search endpoint

### DIFF
--- a/fixtures/example-search-series.json
+++ b/fixtures/example-search-series.json
@@ -1,0 +1,23 @@
+{"search-results": {
+    "searchTime": "9",
+    "total": "1",
+    "limit": "1",
+    "offset": "0",
+    "query": "(id:20160119999) AND oc_organization:mh_default_org AND (oc_acl_read:ROLE_ADMIN OR oc_acl_read:ROLE_USER OR oc_acl_read:MATTERHORN_ADMINISTRATOR OR oc_acl_read:ROLE_OAUTH_USER OR oc_acl_read:ROLE_ANONYMOUS) AND -oc_mediatype:AudioVisual AND -oc_deleted:[* TO *]",
+    "result": {
+        "org": "mh_default_org",
+        "id": "20160119999",
+        "dcExtent": -1,
+        "dcTitle": "Test Fall 2016",
+        "dcSubject": "TEST E-19999",
+        "dcCreator": "Harvard Extension School",
+        "dcPublisher": "Harvard University, DCE",
+        "dcContributor": "Henry H. Leitner",
+        "dcDescription": "http://extension.harvard.edu",
+        "dcLanguage": "eng",
+        "mediaType": "Series",
+        "keywords": "",
+        "modified": "2015-09-04T16:37:26.202-04:00",
+        "score": 1.5416209
+    }
+}}

--- a/paella-matterhorn/javascript/05_initdelegate.js
+++ b/paella-matterhorn/javascript/05_initdelegate.js
@@ -60,7 +60,7 @@ function initPaellaMatterhorn(episodeId, onSuccess, onError) {
 					   // end #DCE logging helper
 					   if (serie != undefined) {
 						// #DCE get series from Search endpoint
-						var seriesData = searchSeriesToSeriesSeries(serie, function(seriesData) {
+						searchSeriesToSeriesSeries(serie, function(seriesData) {
 						    if (!paella.matterhorn.serie)  paella.matterhorn.serie = [];
 						    paella.matterhorn.serie[ 'http://purl.org/dc/terms/'] = seriesData;
 						});

--- a/paella-matterhorn/javascript/05_initdelegate.js
+++ b/paella-matterhorn/javascript/05_initdelegate.js
@@ -61,7 +61,13 @@ function initPaellaMatterhorn(episodeId, onSuccess, onError) {
 						
 						if (serie != undefined) {
 							// #DCE get series from Search endpoint
-							searchSeriesToSeriesSeries(serie);
+							var seriesData = searchSeriesToSeriesSeries(serie);
+							if (seriesData) {
+							    paella.matterhorn.serie[ 'http://purl.org/dc/terms/'] = seriesData;
+							    if (onSuccess) onSuccess();
+							} else {
+							    if (onError) onError();
+							}
 						}
 						else {
 							if (onSuccess) onSuccess();						
@@ -133,11 +139,12 @@ var searchSeriesToSeriesSeries = function (seriesId) {
         }
     },
     function (data, contentType, code) {
-        var jsonData;
+        var jsonData = data;
         try {
-            jsonData = JSON.parse(data);
+            if (typeof (jsonData) == "string") jsonData = JSON.parse(jsonData);
         }
         catch (e) {
+            showLoadErrorMessage("Unable to parse series id" + "\"" + serie + "\" data: " + data);
             return false;
         }
         // #DCE verify that results returned at least one series
@@ -158,9 +165,9 @@ var searchSeriesToSeriesSeries = function (seriesId) {
             if (! paella.matterhorn.serie) {
                 paella.matterhorn.serie =[];
             }
-            paella.matterhorn.serie[ 'http://purl.org/dc/terms/'] = dcObject;
+            return dceObject;
         }
-    });
+    })
 };
 // #DCE(karen): END transform series format
 // ------------------------------------------------------------

--- a/paella-matterhorn/javascript/05_initdelegate.js
+++ b/paella-matterhorn/javascript/05_initdelegate.js
@@ -141,18 +141,20 @@ var searchSeriesToSeriesSeries = function (serie, onSuccess, onError) {
             if (typeof (jsonData) == "string") jsonData = JSON.parse(jsonData);
         }
         catch (e) {
-            showLoadErrorMessage("Unable to parse series id" + "\"" + serie + "\" data: " + data);
-            if (typeof(onError)=='function') {
-		onError();
-	    }
+            showLoadErrorMessage(paella.dictionary.translate("Unable to parse series id") + "\"" + serie + "\" data: " + data);
+            if (typeof (onError) == 'function') {
+                onError();
+            }
+            return;
         }
         // #DCE verify that results returned at least one series
         var totalItems = parseInt(jsonData[ 'search-results'].total);
         if (totalItems === 0) {
             showLoadErrorMessage(paella.dictionary.translate("No series found for series id") + ": \"" + serie + "\"");
-            if (typeof(onError)=='function') {
-	         onError();
-	    }
+            if (typeof (onError) == 'function') {
+                onError();
+            }
+            return;
         } else {
             var dcObject = {};
             var seriesResult = jsonData[ 'search-results'].result;
@@ -164,9 +166,9 @@ var searchSeriesToSeriesSeries = function (serie, onSuccess, onError) {
                     "value": seriesResult[key]
                 }];
             }
-            if (typeof(onSuccess)=='function') {
- 		onSuccess(dcObject);
-	    }
+            if (typeof (onSuccess) == 'function') {
+                onSuccess(dcObject);
+            }
         }
     });
 };

--- a/test-server.js
+++ b/test-server.js
@@ -16,6 +16,10 @@ var cannedEpisode = jsonfile.readFileSync(
   // __dirname + '/fixtures/example-live-choppy-episode.json'
 );
 
+var cannedSeries = jsonfile.readFileSync(
+  __dirname + '/fixtures/example-search-series.json'
+);
+
 var cannedMe = jsonfile.readFileSync(
   __dirname + '/fixtures/example-me.json'
 );
@@ -34,6 +38,9 @@ router.get('/info/me.json*', me);
 
 // // Serve a canned episode for episode requests.
 router.get('/search/episode.json*', episode);
+
+// // Serve a canned serues for series requests.
+router.get('/search/series.json*', series);
 
 // Handle everything else with the proxy back to the Matterhorn server.
 router.get('/*', passToProxy);
@@ -61,6 +68,11 @@ function episode(req, res) {
 function me(req, res) {
   console.log('Serving me.json.');
   res.json(cannedMe);
+}
+
+function series(req, res) {
+  console.log('Serving search-series.');
+  res.json(cannedSeries);
 }
 
 function passToProxy(req, res) {


### PR DESCRIPTION
This gets the series data from Engage server's Search endpoint and transforms it to the expected UPV upstream series format for existing plugins. It replaces the original call to the Admin server's Series endpoint.

