### PR TITLE
MATT-1648 fix prod-support, pub-date, and capture-agent help form params

### DIFF
--- a/paella-matterhorn/plugins/edu.harvard.dce.infoButtonPlugin/dce_infobutton.js
+++ b/paella-matterhorn/plugins/edu.harvard.dce.infoButtonPlugin/dce_infobutton.js
@@ -43,8 +43,8 @@ Class ('paella.plugins.InfoPlugin', paella.ButtonPlugin,{
           paramsP += paella.matterhorn.episode.dcIsPartOf ? '&offeringId=' + paella.matterhorn.episode.dcIsPartOf : '';
           paramsP += paella.matterhorn.episode.dcType ? '&typeNum=' + paella.matterhorn.episode.dcType : '';
           paramsP += paella.matterhorn.episode.dcContributor ? '&ps=' + paella.matterhorn.episode.dcContributor : '';
-          paramsP += paella.matterhorn.episode.dcCreated ? 'cDate=' + paella.matterhorn.episode.dcCreated : '';
-          paramsP += paella.matterhorn.episode.dcSpatial ? 'cAgent=' + paella.matterhorn.episode.dcSpatial : '';
+          paramsP += paella.matterhorn.episode.dcCreated ? '&cDate=' + paella.matterhorn.episode.dcCreated : '';
+          paramsP += paella.matterhorn.episode.dcSpatial ? '&cAgent=' + paella.matterhorn.episode.dcSpatial : '';
         }
         window.open('http://cm.dce.harvard.edu/forms/report.shtml?' + paramsP);
         break;
@@ -54,8 +54,8 @@ Class ('paella.plugins.InfoPlugin', paella.ButtonPlugin,{
           params += paella.matterhorn.episode.dcIsPartOf ? '&offeringId=' + paella.matterhorn.episode.dcIsPartOf : '';
           params += paella.matterhorn.episode.dcType ? '&typeNum=' + paella.matterhorn.episode.dcType : '';
           params += paella.matterhorn.episode.dcContributor ? '&ps=' + paella.matterhorn.episode.dcContributor : '';
-          params += paella.matterhorn.episode.dcCreated ? 'cDate=' + paella.matterhorn.episode.dcCreated : '';
-          params += paella.matterhorn.episode.dcSpatial ? 'cAgent=' + paella.matterhorn.episode.dcSpatial : '';
+          params += paella.matterhorn.episode.dcCreated ? '&cDate=' + paella.matterhorn.episode.dcCreated : '';
+          params += paella.matterhorn.episode.dcSpatial ? '&cAgent=' + paella.matterhorn.episode.dcSpatial : '';
         }
         window.open('http://cm.dce.harvard.edu/forms/feedback.shtml?' + params);
         break;


### PR DESCRIPTION
Re-adding the '&' separators that went missing in https://github.com/harvard-dce/paella-matterhorn/commit/a705f9dd995a0f91d52c21da0db1cb53aeb22957#diff-179a747f029d0b7370d5f80cf1160947 to enable help form to parse the params.