### PR TITLE
Route based seek

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -201,6 +201,7 @@ module.exports = function(grunt) {
 		[
 			'update_submodules',
 			'make:copy-extensions-to-paella',
+			'make:build-app-index',
 			'subgrunt:paella',
 			'copy:paella',
 			'checksyntax',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -201,12 +201,12 @@ module.exports = function(grunt) {
 		[
 			'update_submodules',
 			'make:copy-extensions-to-paella',
-			'make:build-app-index',
 			'subgrunt:paella',
 			'copy:paella',
 			'checksyntax',
 			'build_matterhorn_css',
 			'concat:paella_matterhorn.js',
+			'make:build-app-index',
 			'merge-json'
 		]
 	);

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PAELLADIR = submodules/paella
 EXTDIR = node_modules/dce-paella-extensions
 UIDIR = paella-matterhorn/ui
+BROWSERIFYCMD = node_modules/.bin/browserify
 
 copy-extensions-to-paella: \
 	copy-vendor-extensions-to-paella \
@@ -32,3 +33,7 @@ copy-config-to-paella:
 
 run-test-server:
 	node test-server.js
+
+# TODO: uglify-js, source map build.
+build-app-index:
+	$(BROWSERIFYCMD) app-src/index.js > build/javascript/app-index.js

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Dependencies
 
 dce-paella-extensions is a dependency that contains DCE-specific Paella changes. Its version is specified as a tilde range, which means that NPM will install the latest version of dce-paella-extensions that matches the major and minor versions. e.g. If ~1.0.27 is the version in package.json, NPM will install the 1.0.30 if it is available. It will not install 1.1.0. You need to change the version in package.json if you want that version.
 
+[player-router](https://github.com/harvard-dce/player-router) handles URL hash-based routing. app-src/index.js is the module within paella-matterhorn that handles webapp functionality external to Paella.
 
 Running locally
 ---------------

--- a/app-src/index.js
+++ b/app-src/index.js
@@ -1,0 +1,27 @@
+var initPlayerRouter = require('@harvard-dce/player-router');
+var pathExists = require('object-path-exists');
+
+var seekMethodPath = ['player', 'videoContainer', 'seekToTime'];
+
+var router = initPlayerRouter({
+  seeking: {
+    seekParamName: 'start',
+    seekResponder: seekWhenPaellaIsReady
+  }
+});
+
+router.route();
+
+function seekWhenPaellaIsReady(time) {
+  seek();
+
+  function seek() {
+    if (pathExists(paella, seekMethodPath)) {
+      $(document).off('paella:loadComplete', seek);
+      paella.player.videoContainer.seekToTime(time);
+    }
+    else {
+      $(document).on('paella:loadComplete', seek);
+    }
+  }
+}

--- a/app-src/index.js
+++ b/app-src/index.js
@@ -5,20 +5,21 @@ var seekMethodPath = ['player', 'videoContainer', 'seekToTime'];
 
 var router = initPlayerRouter({
   seeking: {
-    seekParamName: 'start',
+    seekParamName: 't',
     seekResponder: seekWhenPaellaIsReady
   }
 });
 
 router.route();
 
-function seekWhenPaellaIsReady(time) {
+function seekWhenPaellaIsReady(startTime, endTime) {
   seek();
+  // TODO: Implement endTime support.
 
   function seek() {
     if (pathExists(paella, seekMethodPath)) {
       $(document).off('paella:loadComplete', seek);
-      paella.player.videoContainer.seekToTime(time);
+      paella.player.videoContainer.seekToTime(startTime);
     }
     else {
       $(document).on('paella:loadComplete', seek);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "url": "https://github.com/harvard-dce/paella-matterhorn.git"
   },
   "dependencies": {
-    "dce-paella-extensions": "~1.1.30"
+    "@harvard-dce/player-router": "^1.0.1",
+    "browserify": "^12.0.1",
+    "dce-paella-extensions": "~1.1.30",
+    "object-path-exists": "^1.0.0"
   },
   "devDependencies": {
     "express": "^4.6.1",
@@ -33,4 +36,3 @@
     "jsonfile": "^2.2.1"
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/harvard-dce/paella-matterhorn.git"
   },
   "dependencies": {
-    "@harvard-dce/player-router": "^1.0.1",
+    "@harvard-dce/player-router": "^1.1.0",
     "browserify": "^12.0.1",
     "dce-paella-extensions": "~1.1.30",
     "object-path-exists": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@harvard-dce/player-router": "^1.1.0",
     "browserify": "^12.0.1",
     "dce-paella-extensions": "~1.1.30",
+    "hcat": "^1.0.1",
     "object-path-exists": "^1.0.0"
   },
   "devDependencies": {

--- a/paella-matterhorn/ui/watch.html
+++ b/paella-matterhorn/ui/watch.html
@@ -11,6 +11,8 @@
     <script type="text/javascript" src="javascript/paella_player.js"></script>
 
     <script type="text/javascript" src="resources/bootstrap/js/bootstrap.min.js"></script>
+    <script src="javascript/app-index.js"></script>
+
     <link rel="stylesheet" href="resources/style/style_dark.css" type="text/css" media="screen" charset="utf-8" />
     <link rel="stylesheet" href="resources/style/matterhorn-style.css" type="text/css" media="screen" charset="utf-8" />
 


### PR DESCRIPTION
This PR enables users to use routes that specify where to start playing via a t parameter. e.g.:

http://server/player/watch.html?id=74b6c02f-afbb-42bc-8145-344153a1792e#t=10-20

Where `t` specifies where to start and stop. `10` meaning "start at ten seconds` and `20` meaning "stop at 20 seconds" in this example. Stopping is not yet implemented, but it will seek to 10 seconds when Paella is ready.

Routing code is in another module which should also be reviewed: [player-router](https://github.com/harvard-dce/player-router).