### PR TITLE
T/matt 1962 fix paella copyright year

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "paella-engage-ui",
-  "version": "4.0.10",
+  "version": "4.0.11",
   "dependencies": {
     "browserify": {
       "version": "12.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paella-engage-ui",
-  "version": "4.0.10",
+  "version": "4.0.11",
   "description": "Paella Player for Matterhorn",
   "repository": {
     "type": "git",

--- a/paella-matterhorn/ui/watch.html
+++ b/paella-matterhorn/ui/watch.html
@@ -32,9 +32,10 @@
         <div class="secondary">
           <a href="//www.extension.harvard.edu/help/privacy-policy" id="privacyPolicy">Privacy</a> ::
           <a href="/engage/ui/pubList.html#/tos" id="terms">Terms of Use</a> ::
-          <span id="copyright">&#169;2015 President and Fellows of Harvard College</span>
+          <span id="copyright">&#169;2016 President and Fellows of Harvard College</span>
         </div>
       </header>
     </div>
   </body>
 </html>
+


### PR DESCRIPTION
This is a temporary hot fix to update the copyright year. In the long run, this header should be removed or reworked. 