### PR TITLE
MATT-2024 update eirslett to update npm to protect against npm issue …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paella-engage-ui",
-  "version": "4.0.11",
+  "version": "4.0.12",
   "description": "Paella Player for Matterhorn",
   "repository": {
     "type": "git",

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 			<plugin>
 			    <groupId>com.github.eirslett</groupId>
 			    <artifactId>frontend-maven-plugin</artifactId>
-			    <version>0.0.15</version>
+			    <version>0.0.22</version>
 			    
 			    <configuration>
 			        <workingDirectory>.</workingDirectory>
@@ -40,18 +40,18 @@
 			    <executions>
                     <execution>
                         <id>install node and npm</id>
-						<phase>validate</phase>                        
+			<phase>validate</phase>
                         <goals>
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v0.10.26</nodeVersion>
-                            <npmVersion>1.4.3</npmVersion>
+                            <nodeVersion>v0.12.1</nodeVersion>
+                            <npmVersion>2.7.1</npmVersion>
                         </configuration>
                     </execution>
 
                     <execution>
-						<phase>validate</phase>                        
+			<phase>validate</phase>
                         <id>npm install</id>
                         <goals>
                             <goal>npm</goal>
@@ -63,7 +63,7 @@
                     </execution>
 
                     <execution>
-						<phase>compile</phase>                        
+			<phase>compile</phase>
                         <id>grunt</id>
                         <goals>
                             <goal>grunt</goal>


### PR DESCRIPTION
Eirslett 0.0.22 is the latest version that works with mvn 3.0, the default Ubuntu 14.0 mvn.
Eirslett 0.0.22 supports updated node & npm versions which are the current defaults in Opencast v2.x. The npm 2.7.1 can handle gzipped resources, which is what was breaking the current npm 1.x.x
https://github.com/npm/npm/blob/v2.7.1/CHANGELOG.md
Tied to dce matterhorn repo pull 

WARNING!! the Paella submodule build requires access to a global node & npm. Opsworks will deploy the same version to the system as in this pom (nodeVersion 0.12.1, and npmVersion 2.7.1)