### PR TITLE
MATT-2068 remove banner, MATT-2045 presentationOnly res view

### DIFF
--- a/fixtures/example-captions-episode.json
+++ b/fixtures/example-captions-episode.json
@@ -31,7 +31,8 @@
               "tags": {
                 "tag": [
                   "archive",
-                  "engage"
+                  "engage",
+                  "multiaudio"
                 ]
               },
               "url": "https://da4w749qm6awt.cloudfront.net/engage-player/83ebde9d-0812-4071-8fb7-a97c1472ceb9/0baac156-ded4-4a25-b002-49f36ead5fb4/presentation_trimmed.mp4",
@@ -72,7 +73,8 @@
               "tags": {
                 "tag": [
                   "archive",
-                  "engage"
+                  "engage",
+                  "multiaudio"
                 ]
               },
               "url": "https://da4w749qm6awt.cloudfront.net/engage-player/83ebde9d-0812-4071-8fb7-a97c1472ceb9/d7086069-ec1f-4862-a75f-822cbffdee5f/presentation_trimmed.mp4",
@@ -113,7 +115,8 @@
               "tags": {
                 "tag": [
                   "archive",
-                  "engage"
+                  "engage",
+                  "multiaudio"
                 ]
               },
               "url": "https://da4w749qm6awt.cloudfront.net/engage-player/83ebde9d-0812-4071-8fb7-a97c1472ceb9/0bcfae1e-b1c0-4e57-b582-02e833d20041/presenter_trimmed.mp4",
@@ -154,7 +157,8 @@
               "tags": {
                 "tag": [
                   "archive",
-                  "engage"
+                  "engage",
+                  "multiaudio"
                 ]
               },
               "url": "https://da4w749qm6awt.cloudfront.net/engage-player/83ebde9d-0812-4071-8fb7-a97c1472ceb9/924a6001-506a-4af0-b8f3-cdc6873be638/presenter_trimmed.mp4",
@@ -195,7 +199,8 @@
               "tags": {
                 "tag": [
                   "archive",
-                  "engage"
+                  "engage",
+                  "multiaudio"
                 ]
               },
               "url": "https://da4w749qm6awt.cloudfront.net/engage-player/83ebde9d-0812-4071-8fb7-a97c1472ceb9/c9814b83-2151-4510-b127-1c55e3f9aba7/presenter_trimmed.mp4",
@@ -236,7 +241,8 @@
               "tags": {
                 "tag": [
                   "archive",
-                  "engage"
+                  "engage",
+                  "multiaudio"
                 ]
               },
               "url": "https://da4w749qm6awt.cloudfront.net/engage-player/83ebde9d-0812-4071-8fb7-a97c1472ceb9/33281f8b-82c1-442a-9d0e-704035dcbe2e/presentation_trimmed.mp4",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -637,8 +637,8 @@
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
     },
     "dce-paella-extensions": {
-      "version": "1.2.44",
-      "from": "dce-paella-extensions@1.2.44"
+      "version": "1.2.66",
+      "from": "dce-paella-extensions@1.2.66"
     },
     "debug": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "browserify": "^12.0.1",
-    "dce-paella-extensions": "^1.2.44",
+    "dce-paella-extensions": "^1.2.66",
     "object-path-exists": "^1.0.0"
   },
   "devDependencies": {

--- a/paella-matterhorn/ui/watch.html
+++ b/paella-matterhorn/ui/watch.html
@@ -25,14 +25,8 @@
   </head>
   <body id="body" onload="loadPaella('playerContainer');">
     <div id="playerContainer" style="display:block;width:100%">
-      <header id="dceHeader" class="extension">
+      <header id="dceHeaderBannerless">
         <div class="primary">
-          <a href="//www.extension.harvard.edu" title="Harvard Extension School" tabindex="-1" id="extensionHome"></a>
-        </div>
-        <div class="secondary">
-          <a href="//www.extension.harvard.edu/help/privacy-policy" id="privacyPolicy">Privacy</a> ::
-          <a href="/engage/ui/pubList.html#/tos" id="terms">Terms of Use</a> ::
-          <span id="copyright">&#169;2016 President and Fellows of Harvard College</span>
         </div>
       </header>
     </div>


### PR DESCRIPTION
This pull combines MATT-2068  to remove DCE header and copyright text on the player and 
MATT-2045 pin to dce-paella-extensions@1.2.66