### PR TITLE
MATT-2211 add Machine Translated disclaimer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-engage-ui",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "license": "GPL 3.0",
   "description": "DCE modified UPV Paella Player for Matterhorn 5.0.15",
   "repository": {
@@ -20,7 +20,7 @@
     "grunt-parallel": "^0.4.1",
     "grunt-subgrunt": "~1.1.0",
     "http-proxy": "^1.13.2",
-    "dce-paella-extensions": "1.6.6",
+    "dce-paella-extensions": "^1.6.8",
     "browserify": "^12.0.1",
     "object-path-exists": "^1.0.0"
   },

--- a/paella-opencast/plugins/es.upv.paella.opencast.loader/03_videoloader.js
+++ b/paella-opencast/plugins/es.upv.paella.opencast.loader/03_videoloader.js
@@ -191,17 +191,23 @@ var OpencastToPaellaConverter = Class.create({
 		// Note: OC mediapckage does not currently pass Language and Caption format params
 		// So those are hardcoded here as 'dfxp' and 'en' (English)
 		// This is an issue for captions in other languages and formats.
-		var captionURL = getCaptionURL();
-		if (captionURL) {
+		// #DCE is using tags identify extra information (machine or human translation)
+		// The Matterhorn catalogs tags array is really under captionData.tags.tag (not a typo!)
+		// Catalog tags have to be saved in paella.dce because paella.captions is created from caption url results
+		// Example:"catalog": [{.... "tags": {"tag": "archive"}] or  "catalog": [{.... "tags": {"tag": [ "archive", "automated"]}}]
+		var captionData = getCaptionData();
+		if (captionData) {
+			paella.dce = paella.dce || {};
+			paella.dce.captiontags = captionData.tags.tag;
 			data.captions = [];
 			data.captions.push({
-				url: captionURL,
+				url: captionData.url,
 				format: 'dfxp',
 				lang: 'en'
 			});
 		}
 
-		function getCaptionURL() {
+		function getCaptionData() {
 			var catalogs = episode.mediapackage.metadata.catalog;
 			if (!(catalogs instanceof Array)) {
 				catalogs = [catalogs];
@@ -215,9 +221,7 @@ var OpencastToPaellaConverter = Class.create({
 					break;
 				}
 			}
-			if (catalog) {
-				return catalog.url;
-			}
+			return catalog;
 		}
 		// #DCE end get caption url from episode mp
 		return data;

--- a/paella-opencast/plugins/es.upv.paella.opencast.loader/05_initdelegate.js
+++ b/paella-opencast/plugins/es.upv.paella.opencast.loader/05_initdelegate.js
@@ -34,7 +34,7 @@ function loadOpencastPaellaDCE(containerId) {
 			if (data.streams.length < 1) {
 				paella.messageBox.showError("Error loading video! No streams found");
 			}
-			paella.dce = {};
+			paella.dce = paella.dce || {};
 			paella.dce.sources = data.streams;
 			// Hide the slave stream from paella if ios, will be used in singleVideoToggle
 			if (base.userAgent.system.iOS) {


### PR DESCRIPTION
This pull preserves the mediapckage's caption element tags, if captions exist, so they can be accessed later by the transcription plugin. DCE Medpackages tag caption elements "automated" if automatically (machine) generated. The transcription plugin looks for this tag in order to add a disclaimer to the transcription UI. (i.e. machine translation is currently less accurate than human translation).

Note: The  Modifications of this pull are sandwiched between existing DCE modifications of the UPV paella-matterhorn branch (thus they are not re-tagged with #DCE bookends, expand to see the existing #DCE bookends)

Associated transcription plugin's pull that displays the "machine translated" disclaimer:
https://github.com/harvard-dce/dce-paella-extensions/pull/21