### PR TITLE
MATT-1595 re-enable control bar auto-hide (also linked to MATT-2192 Safari10.0.1 fix)

### DIFF
--- a/app-src/index.js
+++ b/app-src/index.js
@@ -30,22 +30,8 @@ function clearDoneUrlCookie() {
     'domain=.harvard.edu; path=/';
 }
 
-function disableAutoHiding() {
-  $(document).on('paella:controlBarLoaded', getRidOfOnPlayEvent);
-
-  function getRidOfOnPlayEvent() {
-    $(document).off('paella:controlBarLoaded', getRidOfOnPlayEvent);
-    paella.player.controls.restartHideTimer = noOp;
-  }
-}
-
-function noOp() {
-}
-
-
 ((function go() {
   setUpParentFrameCommunications(document);
-  disableAutoHiding();
   clearDoneUrlCookie();
   router.route();
 })());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dce-paella-engage-ui",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "license": "GPL 3.0",
   "description": "DCE modified UPV Paella Player for Matterhorn 5.0.15",
   "repository": {
@@ -20,7 +20,7 @@
     "grunt-parallel": "^0.4.1",
     "grunt-subgrunt": "~1.1.0",
     "http-proxy": "^1.13.2",
-    "dce-paella-extensions": "1.6.12",
+    "dce-paella-extensions": "1.6.13",
     "browserify": "^12.0.1",
     "object-path-exists": "^1.0.0"
   },

--- a/paella-opencast/ui/watch.html
+++ b/paella-opencast/ui/watch.html
@@ -13,6 +13,8 @@
 		<script type="text/javascript" src="mh_dce_resources/js/jquery-ui.js"></script>
 		<script type="text/javascript" src="resources/bootstrap/js/bootstrap.min.js"></script>
 		<!-- DCE additional js end -->
+		<!-- DCE adding require back in, UPV uses it to pull in dashjs -->
+		<script type="text/javascript" src="javascript/require.js"></script>
 		<script type="text/javascript" src="javascript/paella_player.js"></script>
 		<script type="text/javascript" src="javascript/app-index.js"></script>
 		<link rel="stylesheet" href="resources/bootstrap/css/bootstrap.slate.min.css" type="text/css" media="screen" charset="utf-8" />

--- a/vendor/paella_overrides/src/06_ui_controls.js
+++ b/vendor/paella_overrides/src/06_ui_controls.js
@@ -720,7 +720,10 @@ Class ("paella.ControlsContainer", paella.DomNode,{
 		function hideIfNotCanceled() {
 			if (This._doHide) {
 				$(This.domElement).css({opacity:0.0});
-				$(This.domElement).hide();
+				// #DCE MATT-1595, already transaprent, leave width alone (no hide!)
+				// fix for staggered control bar plugin display
+				// $(This.domElement).hide();
+				// #DCE MATT-1595 end
 				This.domElement.setAttribute('aria-hidden', 'true');
 				This._hidden = true;
 				paella.events.trigger(paella.events.controlBarDidHide);
@@ -747,14 +750,18 @@ Class ("paella.ControlsContainer", paella.DomNode,{
 	},
 
 	show:function() {
+		// #DCE MATT-1595 change show-hide to opaque-transparent, fix staggered plugin display
+		var This = this;
+		function finishShow() {
+			This.domElement.setAttribute('aria-hidden', 'false');
+			This._hidden = false;
+			paella.events.trigger(paella.events.controlBarDidShow);
+		}
 		if (this.isEnabled) {
 			$(this.domElement).stop();
 			this._doHide = false;
-			this.domElement.style.opacity = 1.0;
-			this.domElement.setAttribute('aria-hidden', 'false');
-			this._hidden = false;
-			$(this.domElement).show();
-			paella.events.trigger(paella.events.controlBarDidShow);
+			// #DCE MATT-1595 only need to make opaque, no size change
+			$(this.domElement).animate({opacity:1.0},{duration:50, complete: finishShow});
 		}
 	},
 


### PR DESCRIPTION
Re-enable the default UPV Paella control-bar auto-hide. 
When re-displaying control bar, some button plugins display before other button plugins. Adding a getMinWindowSize to the parent ButtonPlugin resolved the buttons, but then the time/scrubber bar displayed before all the button plugins.

That looked weird and distracting. To prevent the weird reshow and resizing delays of the elements in  the control bar, the control bar itself, needed to retain it's size while hidden (i.e. transparent). The opacity is already being set to zero. The video is visible in the space where the control bar exists but the control keeps its size and no weird resizing when it becomes visible.
