### PR TITLE
allow test-server to serve static files and mock auth results

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ To avoid having to run `npm publish` and `npm install` in the dce-paella-extensi
 - Run `npm link dce-paella-extensions` in this directory. Now there will be a symlink-like link to your local dce-paella-extensions project.
 - Then, run `grunt build.debug` in this directory to rebuild the project.
 
+If needed, static files, such as `.html` mockups, can be served by dropping into the `/static` directory.
 
+By default, the player auth requests to `/search/episode.json` will be proxied. To serve a canned authResult response make a copy of `fixtures/test-auth/_mpid_.json` and name according to the mpid being used.
 
 Tests
 -----

--- a/fixtures/test-auth/_mpid_.json
+++ b/fixtures/test-auth/_mpid_.json
@@ -1,0 +1,20 @@
+{
+  "_comment": [
+    "This is an example auth result json response of the kind returned by /search/epiosde.json requests. ",
+    "To have the test server return this rather than proxying the request, make a copy of this example ",
+    "and name it according to the mpid, e.g., 3fb07e12-458a-4119-b4ec-a9f9f28146da&.json. If the ",
+    "doneUrlCookie and dceLocation values are important you can extract the appropriate values from ",
+    "a real request in your browser's dev tools network tab."
+  ],
+  "dce-auth-results": {
+    "dceErrorMessage": "You must log in order to gain access to /2017/02/29997/L01",
+    "dceUserId": "not_available",
+    "dceUserGroups": "not_available",
+    "dceResource": "not_available",
+    "dceReturnStatus": 401,
+    "doneUrlCookie": "encrypted-done-url-cookie-value",
+    "dceLocation": "https://cm.auth.example.harvard.edu/login/cas.mhtml?done=[done-url]&logLevel=DEBUG&error=[errmsg]",
+    "dceUserIdType": "not_available"
+  }
+}
+

--- a/static/iframedMultiStartEnd.html
+++ b/static/iframedMultiStartEnd.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Example static file</title>
+  </head>
+  <body>
+    <div class="show-content user_content clearfix enhanced">
+      <h1 class="page-title">Week 3 Videos on Positive Emotions</h1>
+      <p>Example of embedding multiple players in a single page with varying start/end times.</p>
+      <h2>Part 1</h2>
+      <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"><iframe
+          style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
+          src="https://paella-test-server.harvard.edu:3000/engage/player/watch.html?id=3fb07e12-458a-4119-b4ec-a9f9f28146da&amp;start=100&amp;end=600&logLevel=DEBUG"
+          allowfullscreen="allowfullscreen" width="300" height="150"></iframe></div>
+      <h2>Part 2</h2>
+      <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"><iframe
+          style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
+          src="https://paella-test-server.harvard.edu:3000/engage/player/watch.html?id=ebff521e-f1ff-4f33-bae2-79cba4d11d23&amp;start=200&amp;end=700&logLevel=DEBUG"
+          allowfullscreen="allowfullscreen" width="300" height="150"></iframe></div>
+      <h2>Part 3</h2>
+      <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"><iframe
+          style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
+          src="https://paella-test-server.harvard.edu:3000/engage/player/watch.html?id=20015860-5332-4e86-a179-826ef37e0bf1&amp;start=300&amp;end=800&logLevel=DEBUG"
+          allowfullscreen="allowfullscreen" width="300" height="150"></iframe></div>
+      <h2>Part 4</h2>
+      <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"><iframe
+          style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
+          src="https://paella-test-server.harvard.edu:3000/engage/player/watch.html?id=96aa4187-0f57-4934-bb75-174af497ec6a&amp;start=400&amp;end=900&logLevel=DEBUG"
+          allowfullscreen="allowfullscreen" width="300" height="150"></iframe></div>
+    </div>
+  </body>
+</html>

--- a/test-server.js
+++ b/test-server.js
@@ -122,8 +122,13 @@ router.get('/*', passToProxy);
 app.use('/engage/player', express.static('build/paella-opencast'));
 app.use('/engage/player', express.static('build/paella-opencast/resources'));
 app.use('/engage/player/test_media', express.static('fixtures/test_media'));
-app.use('/', router);
 
+if (fs.existsSync('./static', fs.constants.R_OK | fs.constants.W_OK)) {
+  app.use('/static', express.static('static'));
+  console.log("serving static files from ./static");
+}
+
+app.use('/', router);
 
 function skipToContent(req, res, next) {
   log('Skipping to', mostRecentWatchReqUrl);
@@ -139,8 +144,16 @@ function swallow(req, res, next) {
 }
 
 function episode(req, res) {
-  log('Serving episode.');
-  res.json(cannedEpisode);
+  var mpid = req.query.id;
+  var cannedAuthFixture = __dirname + '/fixtures/test-auth/'+ mpid + '.json';
+  if (fs.existsSync(cannedAuthFixture)) {
+    log('Serving auth result.');
+    var authResult = jsonfile.readFileSync(cannedAuthFixture);
+    res.json(authResult);
+  } else {
+    log('Serving episode.');
+    res.json(cannedEpisode);
+  }
 }
 
 function me(req, res) {


### PR DESCRIPTION
This is just a couple of test-server additions that were helpful when working on the multi-embedded player start/end param stuff.