### PR TITLE
MATT-2504 ff captions off button

### DIFF
--- a/vendor/paella_overrides/src/05_plugin_base.js
+++ b/vendor/paella_overrides/src/05_plugin_base.js
@@ -297,7 +297,12 @@ Class ("paella.PopUpContainer", paella.DomNode,{
 			let popUpId = identifier;
 			let btn = button;
 			$(domElement).mouseleave(function(evt) {
-				paella.player.controls.playbackControl().hidePopUp(popUpId,btn);
+				// #DCE MATT-2504 FF-captions-Off-button issue
+				// Unable to find related Mozilla mouseleave bug report, but
+				// Fix ref: https://stackoverflow.com/questions/13359545/mouseenter-mouseleave-in-firefox
+				if (evt.target.nodeName.toLowerCase() !== "select") {
+					paella.player.controls.playbackControl().hidePopUp(popUpId, btn);
+				}
 			});
 		}
 		


### PR DESCRIPTION
There is a known issue with Firefox and mouseleave when the mouse is in a select node within the parent element. 

UPV solved the issue by turning off the Closed Caption's auto close on mouseleave all together[1]. But that  changes the current student experience and is not as user friendly. This pull preserves the mouseleave auto-close experience and also protects other plugins from the Firefox mouseleave-on-option-select-hover issue. 

[1] https://github.com/polimediaupv/paella/commit/34f99cfcfe6bc9a52331bdab2a0c4948102cd716#diff-3e14c8df97bda214b057ebf6be5dc27e